### PR TITLE
Suite links in subheader

### DIFF
--- a/qunit-composite.css
+++ b/qunit-composite.css
@@ -11,3 +11,37 @@
 
     background: #fff;
 }
+
+#qunit-testsuites {
+    margin: 0;
+    padding: 0.5em 1.0em;
+    font-family: "Helvetica Neue Light","HelveticaNeue-Light","Helvetica Neue",Calibri,Helvetica,Arial,sans-serif;
+    font-size: small;
+    background-color: #d2e0e6;
+    border-bottom: 1px solid #fff;
+}
+
+#qunit-testsuites a {
+    color: #00c;
+    text-decoration: none;
+}
+
+#qunit-testsuites a:hover {
+    text-decoration: underline;
+}
+
+#qunit-testsuites > li {
+    display: inline-block;
+}
+
+#qunit-testsuites > li:first-child::before {
+    content: "Suites: ";
+}
+
+#qunit-testsuites > li + li::before {
+    content: "|\a0";
+}
+
+#qunit-testsuites > li::after {
+    content: "\a0";
+}

--- a/qunit-composite.js
+++ b/qunit-composite.js
@@ -131,11 +131,11 @@ function appendSuitesToHeader( suites ) {
 
 	for (i = 0, suitesLen = suites.length; i < suitesLen; ++i) {
 		suite = suites[i];
-		newSuiteLinkEl = document.createElement("A");
+		newSuiteLinkEl = document.createElement("a");
 		newSuiteLinkEl.innerHTML = suite.name || suite;
 		newSuiteLinkEl.href = suite.path || suite;
 
-		newSuiteListItemEl = document.createElement("LI");
+		newSuiteListItemEl = document.createElement("li");
 		newSuiteListItemEl.appendChild(newSuiteLinkEl);
 
 		suitesEl.appendChild(newSuiteListItemEl);

--- a/qunit-composite.js
+++ b/qunit-composite.js
@@ -109,37 +109,37 @@ function initIframe() {
 
 function appendSuitesToHeader( suites ) {
 	var i, suitesLen, suite, path, name, suitesEl, testResultEl,
-        newSuiteListItemEl, newSuiteLinkEl;
+		newSuiteListItemEl, newSuiteLinkEl;
 
 	suitesEl = document.getElementById("qunit-testsuites");
 
 	if (!suitesEl) {
 		testResultEl = document.getElementById("qunit-testresult");
 
-        if (!testResultEl) {
-            // QUnit has not been set up yet. Defer until QUnit is ready.
-            QUnit.begin(function () {
-                appendSuitesToHeader(suites);
-            });
-            return;
-        }
+		if (!testResultEl) {
+			// QUnit has not been set up yet. Defer until QUnit is ready.
+			QUnit.begin(function () {
+				appendSuitesToHeader(suites);
+			});
+			return;
+		}
 
 		suitesEl = document.createElement("ul");
-        suitesEl.id = "qunit-testsuites";
-        testResultEl.parentNode.insertBefore(suitesEl, testResultEl);
+		suitesEl.id = "qunit-testsuites";
+		testResultEl.parentNode.insertBefore(suitesEl, testResultEl);
 	}
 
-    for (i = 0, suitesLen = suites.length; i < suitesLen; ++i) {
-        suite = suites[i];
-        newSuiteLinkEl = document.createElement("A");
-        newSuiteLinkEl.innerHTML = suite.name || suite;
-        newSuiteLinkEl.href = suite.path || suite;
+	for (i = 0, suitesLen = suites.length; i < suitesLen; ++i) {
+		suite = suites[i];
+		newSuiteLinkEl = document.createElement("A");
+		newSuiteLinkEl.innerHTML = suite.name || suite;
+		newSuiteLinkEl.href = suite.path || suite;
 
-        newSuiteListItemEl = document.createElement("LI");
-        newSuiteListItemEl.appendChild(newSuiteLinkEl);
+		newSuiteListItemEl = document.createElement("LI");
+		newSuiteListItemEl.appendChild(newSuiteLinkEl);
 
-        suitesEl.appendChild(newSuiteListItemEl);
-    }
+		suitesEl.appendChild(newSuiteListItemEl);
+	}
 }
 
 /**
@@ -157,7 +157,7 @@ QUnit.testSuites = function( name, suites ) {
 	}
 	suitesLen = suites.length;
 
-    appendSuitesToHeader(suites);
+	appendSuitesToHeader(suites);
 
 	if ( !hasBound ) {
 		hasBound = true;

--- a/qunit-composite.js
+++ b/qunit-composite.js
@@ -107,6 +107,41 @@ function initIframe() {
 	iframeWin = iframe.contentWindow;
 }
 
+function appendSuitesToHeader( suites ) {
+	var i, suitesLen, suite, path, name, suitesEl, testResultEl,
+        newSuiteListItemEl, newSuiteLinkEl;
+
+	suitesEl = document.getElementById("qunit-testsuites");
+
+	if (!suitesEl) {
+		testResultEl = document.getElementById("qunit-testresult");
+
+        if (!testResultEl) {
+            // QUnit has not been set up yet. Defer until QUnit is ready.
+            QUnit.begin(function () {
+                appendSuitesToHeader(suites);
+            });
+            return;
+        }
+
+		suitesEl = document.createElement("ul");
+        suitesEl.id = "qunit-testsuites";
+        testResultEl.parentNode.insertBefore(suitesEl, testResultEl);
+	}
+
+    for (i = 0, suitesLen = suites.length; i < suitesLen; ++i) {
+        suite = suites[i];
+        newSuiteLinkEl = document.createElement("A");
+        newSuiteLinkEl.innerHTML = suite.name || suite;
+        newSuiteLinkEl.href = suite.path || suite;
+
+        newSuiteListItemEl = document.createElement("LI");
+        newSuiteListItemEl.appendChild(newSuiteLinkEl);
+
+        suitesEl.appendChild(newSuiteListItemEl);
+    }
+}
+
 /**
  * @param {string} [name] Module name to group these test suites.
  * @param {Array} suites List of suites where each suite
@@ -121,6 +156,8 @@ QUnit.testSuites = function( name, suites ) {
 		name = "Composition #" + modules++;
 	}
 	suitesLen = suites.length;
+
+    appendSuitesToHeader(suites);
 
 	if ( !hasBound ) {
 		hasBound = true;

--- a/test/index.html
+++ b/test/index.html
@@ -10,7 +10,10 @@
 	<script>
 		QUnit.testSuites([
 			"./foo.html",
-			"./bar.html",
+			"./bar.html"
+		]);
+
+		QUnit.testSuites([
 			{ name: "Quux Test Suite", path: "./quux.html" }
 		]);
 	</script>


### PR DESCRIPTION
It is possible to visit individual test suites by clicking on the "Rerun" links after the test run has finished, but until that point, there is no easy way to get to the individual suites in case of a misclick. In addition, if the QUnit test runner stops prematurely due to an unhandled exception, not all suite links may be available.

This pull request just adds the suites at the top of the test list. It could probably use some CSS help but otherwise works well and doesn't look too bad.

I've also proved out with this pull request that it's possible to call `QUnit.testSuites` multiple times with no ill effects (and the suite links are still rendered correctly).