### PR TITLE
Breaking: Consuming QUnit 2.0 APIs and removing back-compat code

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-qunit": "^1.1.0",
     "grunt-git-authors": "^3.1.1",
-    "qunitjs": "^1.23.0"
+    "qunitjs": "^2.0.0"
   }
 }

--- a/qunit-composite.js
+++ b/qunit-composite.js
@@ -14,7 +14,7 @@
 		factory( QUnit );
 	}
 }(function( QUnit ) {
-var iframe, hasBound,
+var iframe, hasBound, resumeTests, suiteAssert,
 	modules = 1,
 	executingComposite = false;
 
@@ -48,7 +48,9 @@ function runSuite( suite ) {
 		path = suite;
 	}
 
-	QUnit.asyncTest( suite, function() {
+	QUnit.test( suite, function( assert ) {
+		resumeTests = assert.async();
+		suiteAssert = assert;
 		iframe.setAttribute( "src", path );
 		// QUnit.start is called from the child iframe's QUnit.done hook.
 	});
@@ -90,13 +92,13 @@ function initIframe() {
 			}
 			// Pass all test details through to the main page
 			var message = ( moduleName ? moduleName + ": " : "" ) + testName + ": " + ( data.message || ( data.result ? "okay" : "failed" ) );
-			expect( ++count );
-			QUnit.push( data.result, data.actual, data.expected, message );
+			suiteAssert.expect( ++count );
+			suiteAssert.push( data.result, data.actual, data.expected, message );
 		});
 
 		// Continue the outer test when the iframe's test is done
 		iframeWin.QUnit.done(function() {
-			QUnit.start();
+			resumeTests();
 		});
 	}
 
@@ -177,7 +179,7 @@ QUnit.testSuites = function( name, suites ) {
 	}
 
 	QUnit.module( name, {
-		setup: function () {
+		beforeEach: function () {
 			executingComposite = true;
 		}
 	});
@@ -193,16 +195,8 @@ QUnit.testDone(function( data ) {
 	}
 
 	var i, len,
-		testId = data.testId || QUnit.config.current.testId || data.testNumber || QUnit.config.current.testNumber,
-		current = testId ?
-			(
-				// QUnit @^1.16.0
-				document.getElementById( "qunit-test-output-" + testId ) ||
-				// QUnit @1.15.x
-				document.getElementById( "qunit-test-output" + testId )
-			) :
-			// QUnit @<1.15.0
-			document.getElementById( QUnit.config.current.id ),
+		testId = data.testId,
+		current = document.getElementById( "qunit-test-output-" + testId ),
 		children = current && current.children,
 		src = iframe.src;
 


### PR DESCRIPTION
Fixes #8
Fixes #9

Per discussion on the above-linked issues, this PR simply drops compatibility with QUnit <2.0.0 and thus removes some of the cruft centered around checking for different internal reporting attributes.

@JamesMGreene I'm not too happy about having to introduce two new closure variables. Please do take a good look and let me know if those could be handled better. Also, please let me know if I should be modifying the tests at all (I don't think so since the plugin functionality is meant to be unchanged).
